### PR TITLE
Skip Harfbuzz dependency on glib

### DIFF
--- a/.github/workflows/lwjgl.yml
+++ b/.github/workflows/lwjgl.yml
@@ -12,7 +12,7 @@ env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   S3_PARAMS: --cache-control "public,must-revalidate,proxy-revalidate,max-age=0"
-  FREETYPE_PARAMS: --wrap-mode=default --force-fallback-for=harfbuzz,libpng,zlib -Dbrotli=disabled -Dbzip2=disabled -Dharfbuzz=enabled -Dpng=enabled -Dzlib=system -Dtests=disabled -Dbuildtype=release -Dfreetype2:zlib=disabled -Dfreetype2:png=disabled -Dharfbuzz:experimental_api=true -Db_lto=true -Db_ndebug=true -Derror_strings=true
+  FREETYPE_PARAMS: --wrap-mode=default --force-fallback-for=harfbuzz,libpng,zlib -Dbrotli=disabled -Dbzip2=disabled -Dharfbuzz=enabled -Dpng=enabled -Dzlib=system -Dtests=disabled -Dbuildtype=release -Dfreetype2:zlib=disabled -Dfreetype2:png=disabled -Dharfbuzz:experimental_api=true -Dharfbuzz:glib=disabled -Db_lto=true -Db_ndebug=true -Derror_strings=true
 
 jobs:
   linux:


### PR DESCRIPTION
glib is not strictly required by Harfbuzz - if not present, Harfbuzz [will use its built-in Unicode character table](https://github.com/harfbuzz/harfbuzz/blob/main/CONFIG.md#unicode-functions). LWGJL does not seem to make use of glib, however these bindings do include the glib dependency (given GitHub runners have it installed by default). 

The built-in Unicode table was previously included and used over glib anyway, so this change doesn't come with an additional size cost.

This resolves some issues that we have seen with LWJGL's Freetype bindings failing to load on certain systems (particularly, MacOS x86_64) due to missing glib. The error was a bit cryptic, however:
```
Caused by: java.lang.UnsatisfiedLinkError: Failed to dynamically load library: /Users/<user>/Library/Application Support/minecraft/bin/e070375db1e86ab77c6abaa784ddcfb02c253eaa/libfreetype.dylib(error = null)
```
We weren't able to identify exactly what was going wrong with `dlerror()` returning `null`, however, adding an additional call to `dlerror()` before `dlopen()` revealed this error:
```
dlopen(<path>/libfreetype.dylib, 0x0005): Library not loaded: /usr/local/opt/glib/lib/libglib-2.0.0.dylib
  Referenced from: <8860D930-9A0F-3288-8EB9-354EB76CE3BC> <path>/libfreetype.dylib
  Reason: tried: '/usr/local/opt/glib/lib/libglib-2.0.0.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/usr/local/opt/glib/lib/libglib-2.0.0.dylib' (no such file), '/usr/local/opt/glib/lib/libglib-2.0.0.dylib' (no such file), '/usr/lib/libglib-2.0.0.dylib' (no such file, not in dyld cache))
```

This pointed us towards removing the glib dependency, as it seems unneeded for LWJGL's case as far as we could tell.

Thanks!
